### PR TITLE
Fix for problem with nested sideload defs order

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,67 @@ result:
 }
 ```
 
+### Nested sideloads
+
+```javascript
+var nestedObjects = {
+    name: "root",
+    children : [
+        {
+            cid: 1,
+            name : "child1",
+            grandchildren: [
+                {
+                    gid: 1,
+                    title : "grandChild1"
+                }
+            ]
+        },
+        {
+            cid: 2,
+            name : "child2",
+            grandchildren: [
+                {
+                    gid: 2,
+                    title : "grandChild2"
+                },
+                {
+                    gid: 3,
+                    title : "grandChild3"
+                }
+            ]
+        }
+    ]
+};
+
+var config = {
+    wrapper: { singular : 'root' },
+    sideloading: [
+        { property : 'children', idAttribute : 'cid', as: 'children'},
+        { property : 'children.grandchildren', idAttribute : 'gid', as: 'grandchildren'}
+    ]
+};
+
+var result = sideloadify(book, config);
+```
+
+result:
+```javascript
+{
+    root: { name: "root", children: [1, 2] },
+    children: [
+        { cid: 1, name: "child1", grandchildren: [1] },
+        { cid: 2, name: "child2", grandchildren: [2, 3] }
+    ],
+    grandchildren: [
+        { gid: 1, title: "grandChild1" },
+        { gid: 2, title: "grandChild2" },
+        { gid: 3, title: "grandChild3" }
+    ]
+}
+```
+
+
 ### Single object sideload
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ var _ = require('lodash'),
  */
 module.exports = function sideloadify(target, options) {
     var inputClone, inputAsArray, sideloads, results, mainPropertyName, inputIsArray, sideloadSpecs;
+    sortSideloads(options);
     inputIsArray = _.isArray(target);
     inputClone = _.cloneDeep(target);
     inputAsArray = (inputIsArray) ? inputClone : [ inputClone ];
@@ -97,4 +98,20 @@ function removeDuplicatesById(targetArray, idAttrPath) {
 
 function extractSideloaded(fromJson, settings) {
     return objectUtils.replaceWithIdArray(fromJson, settings['property'], settings['idAttribute']);
+}
+
+// Need to make sure the most deeply nested sideloads are extracted before less deeply nested. This
+// can be ensured by sorting sideload specs by the property path length
+function sortSideloads(spec) {
+    if (!spec.sideloading || !spec.sideloading.length || spec.sideloading.length <= 1) {
+        return;
+    }
+    spec.sideloading.sort(function (a, b) {
+        if (a.property.length > b.property.length) {
+            return -1;
+        } else if (a.property.length < b.property.length) {
+            return 1;
+        }
+        return 0;
+    });
 }

--- a/spec/sideloadify_spec.js
+++ b/spec/sideloadify_spec.js
@@ -234,8 +234,8 @@ describe("sideloadify", function (){
         var result = sideloadify(nestedObjects, {
             wrapper: { singular : 'root', plural : 'WRONG' },
             sideloading: [
-                { property : 'children.grandchildren', idAttribute : 'gid', as: 'grandchildren'},
-                { property : 'children', idAttribute : 'cid', as: 'children'}
+                { property : 'children', idAttribute : 'cid', as: 'children'},
+                { property : 'children.grandchildren', idAttribute : 'gid', as: 'grandchildren'}
             ]
         });
         expect(result).toEqual({


### PR DESCRIPTION
There was a problem where if a more deeply nested sideload was defined after a less deeply nested sideload would cause an error. Fixed in this PR